### PR TITLE
Add captions to spell header.

### DIFF
--- a/lib/dndspell.sty
+++ b/lib/dndspell.sty
@@ -2,10 +2,10 @@
   \subtitlesection{#1}{#2}
   \vspace{-1ex} % subtitlesection artefact; topsep also changes bottom spacing.
   \begin{description}[font=\normalfont\textbf,noitemsep,topsep=1ex,leftmargin=1em]
-    \item[Casting Time:] #3
-    \item[Range:] #4
-    \item[Components:] #5
-    \item[Duration:] #6
+    \item[\spellcastingtimename:] #3
+    \item[\spellrangename:] #4
+    \item[\spellcomponentsname:] #5
+    \item[\spelldurationname:] #6
   \end{description}
 }
 

--- a/lib/dndstrings-captions.sty
+++ b/lib/dndstrings-captions.sty
@@ -62,6 +62,11 @@
 %    \renewcommand\innateatwillname{At~will}
 %    \renewcommand\numberperdayname{|1|/day}
 %    \renewcommand\numberperdayeachname{|1|/day~each}
+%    % Spell header
+%    \renewcommand\spellcastingtimename{Casting~Time}
+%    \renewcommand\spellrangename{Range}
+%    \renewcommand\spellcomponentsname{Components}
+%    \renewcommand\spelldurationname{Duration}
 %  }
 
 % Italian captions
@@ -120,6 +125,11 @@
     \renewcommand\innateatwillname{A~volont\`a}
     \renewcommand\numberperdayname{|1|/giorno}
     \renewcommand\numberperdayeachname{|1|/g.~ciascuno}
+    % Spell header
+%    \renewcommand\spellcastingtimename{Casting~Time}
+%    \renewcommand\spellrangename{Range}
+%    \renewcommand\spellcomponentsname{Components}
+%    \renewcommand\spelldurationname{Duration}
   }
 
 % Russian captions
@@ -178,6 +188,11 @@
 %    \renewcommand\innateatwillname{At~will}
 %    \renewcommand\numberperdayname{|1|/day}
 %    \renewcommand\numberperdayeachname{|1|/day~each}
+%    % Spell header
+%    \renewcommand\spellcastingtimename{Casting~Time}
+%    \renewcommand\spellrangename{Range}
+%    \renewcommand\spellcomponentsname{Components}
+%    \renewcommand\spelldurationname{Duration}
   }
 
 \ExplSyntaxOff

--- a/lib/dndstrings.sty
+++ b/lib/dndstrings.sty
@@ -72,6 +72,12 @@
 \newcommand\numberperdayname{|1|/day}
 \newcommand\numberperdayeachname{|1|/day~each}
 
+% Spell Header
+\newcommand\spellcastingtimename{Casting~Time}
+\newcommand\spellrangename{Range}
+\newcommand\spellcomponentsname{Components}
+\newcommand\spelldurationname{Duration}
+
 % Delay loading captions until after the user has imported a language package.
 % Enables using babel/polyglossia with the dndbook document class as well as the
 % dnd package.


### PR DESCRIPTION
I don't know how this has slipped under the radar for so long, but the descriptions in the spell header were hardcoded text. These are now captions.