### PR TITLE
German captions

### DIFF
--- a/lib/dndstrings-captions.sty
+++ b/lib/dndstrings-captions.sty
@@ -238,7 +238,7 @@
     \renewcommand\spelleighthlevelname{8.~Grad}
     \renewcommand\spellninthlevelname{9.~Grad}
     % Spell slots
-    \renewcommand\spellatwillname{jederzeit}
+    \renewcommand\spellatwillname{beliebig oft}
     \renewcommand\spelloneslotname{1~Platz}
     \renewcommand\spelltwoslotsname{2~Plätze}
     \renewcommand\spellthreeslotsname{3~Plätze}
@@ -248,7 +248,7 @@
     \renewcommand\numberperdayname{|1|/Tag}
     \renewcommand\numberperdayeachname{jeweils~|1|/Tag}
     % Spell header
-    \renewcommand\spellcastingtimename{Zauberzeit}
+    \renewcommand\spellcastingtimename{Zeitaufwand}
     \renewcommand\spellrangename{Reichweite}
     \renewcommand\spellcomponentsname{Komponenten}
     \renewcommand\spelldurationname{Wirkungsdauer}

--- a/lib/dndstrings-captions.sty
+++ b/lib/dndstrings-captions.sty
@@ -196,25 +196,25 @@
   }
 
 % German captions
-\addto\captionsngerman{%
-    \def\armorclassname{Rüstungsklasse}%
-    \def\hitpointsname{Trefferpunkte}%
-    \def\speedname{Bewegungsrate}%
-    \def\strstatname{STR}%
-    \def\dexstatname{GES}%
-    \def\constatname{KON}%
-    \def\intstatname{INT}%
-    \def\wisstatname{WEI}%
-    \def\chastatname{CHA}%
-    \def\skillsname{Fertigkeit}%
-    \def\dimmname{Immunitäten}%
-    \def\dvulname{Anfälligkeiten}%
-    \def\dresname{Wiederstandsschaden}%
+\addto\captionsngerman{
+    \def\armorclassname{Rüstungsklasse}
+    \def\hitpointsname{Trefferpunkte}
+    \def\speedname{Bewegungsrate}
+    \def\strstatname{STR}
+    \def\dexstatname{GES}
+    \def\constatname{KON}
+    \def\intstatname{INT}
+    \def\wisstatname{WEI}
+    \def\chastatname{CHA}
+    \def\skillsname{Fertigkeit}
+    \def\dimmname{Immunitäten}
+    \def\dvulname{Anfälligkeiten}
+    \def\dresname{Wiederstandsschaden}
     \def\cimmname{Immunität}
-    \def\savesname{Rettung}%
-    \def\sensesname{Sinne}%
-    \def\languagesname{Sprachen}%
-    \def\challengename{Herausforderung}%
+    \def\savesname{Rettung}
+    \def\sensesname{Sinne}
+    \def\languagesname{Sprachen}
+    \def\challengename{Herausforderung}
     \newcommand\xpname{EP}
     % Monster attack
     \renewcommand\ftname{Fuß}

--- a/lib/dndstrings-captions.sty
+++ b/lib/dndstrings-captions.sty
@@ -206,45 +206,45 @@
     \def\intstatname{INT}
     \def\wisstatname{WEI}
     \def\chastatname{CHA}
-    \def\skillsname{Fertigkeit}
+    \def\skillsname{Fertigkeiten}
     \def\dimmname{Immunitäten}
     \def\dvulname{Anfälligkeiten}
     \def\dresname{Wiederstandsschaden}
     \def\cimmname{Immunität}
-    \def\savesname{Rettung}
+    \def\savesname{Rettungswürfe}
     \def\sensesname{Sinne}
     \def\languagesname{Sprachen}
     \def\challengename{Herausforderung}
     \newcommand\xpname{EP}
     % Monster attack
     \renewcommand\ftname{Fuß}
-    \renewcommand\meleeattackname{Nahkampfangriff}
-    \renewcommand\rangedattackname{Fernkampangriff}
-    \renewcommand\meleeorrangedattackname{Nah-~oder~Fernkampfangriff}
-    \renewcommand\tohitname{um~zu~treffen}
+    \renewcommand\meleeattackname{Nahkampf-Waffenangriff}
+    \renewcommand\rangedattackname{Fernkampf-Waffenangriff}
+    \renewcommand\meleeorrangedattackname{Nah-~oder~Fernkampf-Waffenangriff}
+    \renewcommand\tohitname{zum~Treffen}
     \renewcommand\reachname{Reichweite}
-    \renewcommand\rangename{Bereich}
+    \renewcommand\rangename{Reichweite}
     \renewcommand\hitname{Treffer}
     \renewcommand\damagename{Schaden}
     % Spell levels
     \renewcommand\spellcantripsname{Zaubertricks}
-    \renewcommand\spellfirstlevelname{1.~Stufe}
-    \renewcommand\spellsecondlevelname{2.~Stufe}
-    \renewcommand\spellthirdlevelname{3.~Stufe}
-    \renewcommand\spellfourthlevelname{4.~Stufe}
-    \renewcommand\spellfifthlevelname{5.~Stufe}
-    \renewcommand\spellsixthlevelname{6.~Stufe}
-    \renewcommand\spellseventhlevelname{7.~Stufe}
-    \renewcommand\spelleighthlevelname{8.~Stufe}
-    \renewcommand\spellninthlevelname{9.~Stufe}
+    \renewcommand\spellfirstlevelname{1.~Grad}
+    \renewcommand\spellsecondlevelname{2.~Grad}
+    \renewcommand\spellthirdlevelname{3.~Grad}
+    \renewcommand\spellfourthlevelname{4.~Grad}
+    \renewcommand\spellfifthlevelname{5.~Grad}
+    \renewcommand\spellsixthlevelname{6.~Grad}
+    \renewcommand\spellseventhlevelname{7.~Grad}
+    \renewcommand\spelleighthlevelname{8.~Grad}
+    \renewcommand\spellninthlevelname{9.~Grad}
     % Spell slots
-    \renewcommand\spellatwillname{nach~belieben}
-    \renewcommand\spelloneslotname{1~Slot}
-    \renewcommand\spelltwoslotsname{2~Slots}
-    \renewcommand\spellthreeslotsname{3~Slots}
-    \renewcommand\spellfourslotsname{4~Slots}
+    \renewcommand\spellatwillname{jederzeit}
+    \renewcommand\spelloneslotname{1~Platz}
+    \renewcommand\spelltwoslotsname{2~Plätze}
+    \renewcommand\spellthreeslotsname{3~Plätze}
+    \renewcommand\spellfourslotsname{4~Plätze}
     % Innate spellcasting
-    \renewcommand\innateatwillname{Nach~belieben}
+    \renewcommand\innateatwillname{Jederzeit}
     \renewcommand\numberperdayname{|1|/Tag}
     \renewcommand\numberperdayeachname{|1|/Tag~pro}
     % Spell header

--- a/lib/dndstrings-captions.sty
+++ b/lib/dndstrings-captions.sty
@@ -214,7 +214,7 @@
     \def\savesname{Rettungswürfe}
     \def\sensesname{Sinne}
     \def\languagesname{Sprachen}
-    \def\challengename{Schwierigkeitseinstufung}
+    \def\challengename{Herausforderungsgrad}
     \newcommand\xpname{EP}
     % Monster attack
     \renewcommand\ftname{m}
@@ -244,7 +244,7 @@
     \renewcommand\spellthreeslotsname{3~Plätze}
     \renewcommand\spellfourslotsname{4~Plätze}
     % Innate spellcasting
-    \renewcommand\innateatwillname{Jederzeit}
+    \renewcommand\innateatwillname{Willentlich}
     \renewcommand\numberperdayname{|1|/Tag}
     \renewcommand\numberperdayeachname{jeweils~|1|/Tag}
     % Spell header

--- a/lib/dndstrings-captions.sty
+++ b/lib/dndstrings-captions.sty
@@ -207,17 +207,17 @@
     \def\wisstatname{WEI}
     \def\chastatname{CHA}
     \def\skillsname{Fertigkeiten}
-    \def\dimmname{Immunitäten}
-    \def\dvulname{Anfälligkeiten}
-    \def\dresname{Wiederstandsschaden}
-    \def\cimmname{Immunität}
+    \def\dimmname{Schadensimmunitäten}
+    \def\dvulname{Schadensanfälligkeiten}
+    \def\dresname{Schadensresistenzen}
+    \def\cimmname{Zustandsimmunitäten}
     \def\savesname{Rettungswürfe}
     \def\sensesname{Sinne}
     \def\languagesname{Sprachen}
-    \def\challengename{Herausforderung}
+    \def\challengename{Schwierigkeitseinstufung}
     \newcommand\xpname{EP}
     % Monster attack
-    \renewcommand\ftname{Fuß}
+    \renewcommand\ftname{m}
     \renewcommand\meleeattackname{Nahkampf-Waffenangriff}
     \renewcommand\rangedattackname{Fernkampf-Waffenangriff}
     \renewcommand\meleeorrangedattackname{Nah-~oder~Fernkampf-Waffenangriff}
@@ -246,7 +246,7 @@
     % Innate spellcasting
     \renewcommand\innateatwillname{Jederzeit}
     \renewcommand\numberperdayname{|1|/Tag}
-    \renewcommand\numberperdayeachname{|1|/Tag~pro}
+    \renewcommand\numberperdayeachname{jeweils~|1|/Tag}
     % Spell header
     \renewcommand\spellcastingtimename{Zauberzeit}
     \renewcommand\spellrangename{Reichweite}

--- a/lib/dndstrings-captions.sty
+++ b/lib/dndstrings-captions.sty
@@ -30,7 +30,7 @@
 %    \renewcommand\sensesname{Senses}
 %    \renewcommand\languagesname{Languages}
 %    \renewcommand\challengename{Challenge}
-%    \newcommand\xpname{XP}
+%    \renewcommand\xpname{XP}
 %    % Monster attack
 %    \renewcommand\ftname{ft.}
 %    \renewcommand\meleeattackname{Melee Weapon~Attack}
@@ -93,7 +93,7 @@
     \renewcommand\sensesname{Sensi}
     \renewcommand\languagesname{Linguaggi}
     \renewcommand\challengename{Sfida}
-    \newcommand\xpname{PE}
+    \renewcommand\xpname{PE}
     % Monster attack
     \renewcommand\ftname{m.}
     \renewcommand\meleeattackname{Attacco~con~Arma~da~Mischia}
@@ -156,7 +156,7 @@
     \renewcommand\sensesname{Чувства}
     \renewcommand\languagesname{Языки}
     \renewcommand\challengename{Опасность}
-%    \newcommand\xpname{XP}
+%    \renewcommand\xpname{XP}
 %    % Monster attack
 %    \renewcommand\ftname{ft.}
 %    \renewcommand\meleeattackname{Melee Weapon~Attack}
@@ -197,25 +197,25 @@
 
 % German captions
 \addto\captionsngerman{
-    \def\armorclassname{Rüstungsklasse}
-    \def\hitpointsname{Trefferpunkte}
-    \def\speedname{Bewegungsrate}
-    \def\strstatname{STR}
-    \def\dexstatname{GES}
-    \def\constatname{KON}
-    \def\intstatname{INT}
-    \def\wisstatname{WEI}
-    \def\chastatname{CHA}
-    \def\skillsname{Fertigkeiten}
-    \def\dimmname{Schadensimmunitäten}
-    \def\dvulname{Schadensanfälligkeiten}
-    \def\dresname{Schadensresistenzen}
-    \def\cimmname{Zustandsimmunitäten}
-    \def\savesname{Rettungswürfe}
-    \def\sensesname{Sinne}
-    \def\languagesname{Sprachen}
-    \def\challengename{Herausforderungsgrad}
-    \newcommand\xpname{EP}
+    \renewcommand\armorclassname{Rüstungsklasse}
+    \renewcommand\hitpointsname{Trefferpunkte}
+    \renewcommand\speedname{Bewegungsrate}
+    \renewcommand\strstatname{STR}
+    \renewcommand\dexstatname{GES}
+    \renewcommand\constatname{KON}
+    \renewcommand\intstatname{INT}
+    \renewcommand\wisstatname{WEI}
+    \renewcommand\chastatname{CHA}
+    \renewcommand\skillsname{Fertigkeiten}
+    \renewcommand\dimmname{Schadensimmunitäten}
+    \renewcommand\dvulname{Schadensanfälligkeiten}
+    \renewcommand\dresname{Schadensresistenzen}
+    \renewcommand\cimmname{Zustandsimmunitäten}
+    \renewcommand\savesname{Rettungswürfe}
+    \renewcommand\sensesname{Sinne}
+    \renewcommand\languagesname{Sprachen}
+    \renewcommand\challengename{Herausforderungsgrad}
+    \renewcommand\xpname{EP}
     % Monster attack
     \renewcommand\ftname{m}
     \renewcommand\meleeattackname{Nahkampf-Waffenangriff}


### PR DESCRIPTION
I have split this in three inital commits:
1. Removal of trailing `%` (either we should do that consistently or not)
1. Some of the German captions did not reflect what is used in the official German translations.
1. Changes for other German captions, for which I do not have offcial sources at hand.

Since I don't own the translated versions of the books, I took the [errata](http://www.ulisses-spiele.de/download/2377/DnD5ErrataJanuar2019_841a.pdf) and [starter player character sheets](http://www.ulisses-spiele.de/download/2283/DDDeutscherBogenDownload_0289.pdf) as source (from [here](http://www.ulisses-spiele.de/produkte/1509/dungeons-dragons-players-handbook-spielerhandbuch/)). Sadly, these do not contain all relevant strings, that's why I separated the changes I was not 100% sure about in a separate commit.

Some comments:
- In the offical translations, the words `reach`and `range` both appear to be translated with `Reichweite`.
- `at will` seems to be officially translated with `jederzeit`, though I agree with the choice of @m42e `nach Belieben`. Still I guess we should stick to the official choice of words.

And some comments on the captions without official sources, which is why I think some elaboration is in order. If anyone has a German PHB or MM, please chime in:
- I chose `Schadensimmunitäten`, `Schadensanfälligkeiten` and `Schadensresistenzen` because in English the word `damage` is always used for those. Also I chose `Schadensresistenzen` over `Wiederstandsschaden` because the latter sounds like a damage type, and also because `Resistenzen` is found in the official sources.
- `Zustandsimmunitäten` makes it more distinguishable from `Schadensimmunitäten`.
- Since `Herausforderung` just means `challenge` I came up with `Schwierigkeitseinstufung` for `challenge rating`.
- I chose `jeweils~|1|/Tag` over `|1|/Tag~pro` because it is more like a complete (albeit short) sentence, as is `|1|/day~each`.
- I'm not sure about `Zauberzeit`and `Wirkungsdauer`, but I had no idea which sounds more fitting, so I didn't change them. Would love to see the additional translations on those.
- Concerning `\ftname`: The italian translation (in `dndstrings-captions.sty`) uses `m.`. The russian one uses `ft.`, even though they don't use the imperial system in Russia. The official German sources use `m` (without the period), which it would probably be the correct choice for us.