### PR TITLE
opensans no longer supports small caps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Configured CI to compile example document under pdfTeX, LuaTeX, and XeTeX.
 
+### Changed
+
+* Sans serif title font now provided by kp-fonts
+
 ## [0.7.0] - 2019-02-09
 
 ### Added

--- a/lib/dndfonts.sty
+++ b/lib/dndfonts.sty
@@ -4,16 +4,17 @@
   \renewcommand{\sfdefault}{lmss}
 \fi
 
+\RequirePackage[notext,nomath,nosf,nott]{kpfonts}
 \newcommand{\dnd@TitleFont}{\normalfont\scshape}
 
-\newcommand{\dnd@TableTitleFont}{\fontfamily{fosj}\selectfont\bfseries\scshape}
+\newcommand{\dnd@TableTitleFont}{\fontfamily{jkpss}\selectfont\large\bfseries\scshape}
 \newcommand{\dnd@TableBodyFont}{\sffamily}
 
-\newcommand{\dnd@BoxTitleFont}{\fontfamily{fosj}\selectfont\bfseries\scshape}
+\newcommand{\dnd@BoxTitleFont}{\fontfamily{jkpss}\selectfont\large\bfseries\scshape}
 \newcommand{\dnd@BoxBodyFont}{\sffamily}
 
 \newcommand{\dnd@StatBlockTitleFont}{\normalfont\bfseries\scshape}
-\newcommand{\dnd@StatBlockSubtitleFont}{\fontfamily{fosj}\selectfont\scshape}
+\newcommand{\dnd@StatBlockSubtitleFont}{\fontfamily{jkpss}\selectfont\large\scshape}
 \newcommand{\dnd@StatBlockBodyFont}{\sffamily}
 
 \newcommand{\dnd@FooterFont}{\normalfont\scshape}

--- a/packages.txt
+++ b/packages.txt
@@ -2,6 +2,7 @@
 #
 #   environ: required by tcolorbox
 #   etex-pkg: provides e-TeX, transitive dependency
+#   kpfonts: sans serif font
 #   l3kernel: required by xparse
 #   l3packages: xparse
 #   ms: multitoc, ragged2e
@@ -29,6 +30,7 @@ hang
 ifluatex
 ifxetex
 keycommand
+kpfonts
 l3kernel
 l3packages
 latex-fonts

--- a/packages.txt
+++ b/packages.txt
@@ -2,9 +2,8 @@
 #
 #   environ: required by tcolorbox
 #   etex-pkg: provides e-TeX, transitive dependency
+#   expl3: xparse and LaTeX3
 #   kpfonts: sans serif font
-#   l3kernel: required by xparse
-#   l3packages: xparse
 #   ms: multitoc, ragged2e
 #   oberdiek: luacolor
 #   pgf: tikz
@@ -23,6 +22,7 @@ enumitem
 environ
 etex-pkg
 etoolbox
+expl3
 fancyhdr
 fp
 geometry
@@ -31,8 +31,6 @@ ifluatex
 ifxetex
 keycommand
 kpfonts
-l3kernel
-l3packages
 latex-fonts
 lm
 microtype

--- a/packages.txt
+++ b/packages.txt
@@ -32,10 +32,10 @@ ifluatex
 ifxetex
 keycommand
 kpfonts
-latex-fonts
 l3backend
 l3kernel
 l3packages
+latex-fonts
 lm
 microtype
 ms

--- a/packages.txt
+++ b/packages.txt
@@ -4,6 +4,7 @@
 #   etex-pkg: provides e-TeX, transitive dependency
 #   expl3: xparse and LaTeX3
 #   kpfonts: sans serif font
+#   l3backend
 #   ms: multitoc, ragged2e
 #   oberdiek: luacolor
 #   pgf: tikz
@@ -32,6 +33,7 @@ ifxetex
 keycommand
 kpfonts
 latex-fonts
+l3backend
 lm
 microtype
 ms

--- a/packages.txt
+++ b/packages.txt
@@ -39,7 +39,6 @@ microtype
 ms
 numprint
 oberdiek
-opensans
 pgf
 psnfss
 tcolorbox

--- a/packages.txt
+++ b/packages.txt
@@ -2,9 +2,10 @@
 #
 #   environ: required by tcolorbox
 #   etex-pkg: provides e-TeX, transitive dependency
-#   expl3: xparse and LaTeX3
 #   kpfonts: sans serif font
-#   l3backend
+#   l3backend: xparse dependency
+#   l3kernel: xparse dependency
+#   l3packages: xparse
 #   ms: multitoc, ragged2e
 #   oberdiek: luacolor
 #   pgf: tikz
@@ -23,7 +24,6 @@ enumitem
 environ
 etex-pkg
 etoolbox
-expl3
 fancyhdr
 fp
 geometry
@@ -34,6 +34,8 @@ keycommand
 kpfonts
 latex-fonts
 l3backend
+l3kernel
+l3packages
 lm
 microtype
 ms


### PR DESCRIPTION
The opensans font has dropped support for small caps. kp-fonts can work as a short-term solution while we search for potentially better fonts. This needs to be fixed now because it is causing ci to fail.