### PR TITLE
First pass at translating the captions to Japanese

### DIFF
--- a/lib/dndstrings-captions.sty
+++ b/lib/dndstrings-captions.sty
@@ -142,6 +142,74 @@
 %    \renewcommand\dname{d}
   }
 
+% Japanese captions
+\addto\captionsjapanese
+  {
+    % Monster basics
+    \renewcommand\armorclassname{AC：}
+    \renewcommand\hitpointsname{hp：}
+    \renewcommand\speedname{移動速度：}
+    % Monster ability scores
+    \renewcommand\strstatname{【筋】}
+    \renewcommand\dexstatname{【敏】}
+    \renewcommand\constatname{【耐】}
+    \renewcommand\intstatname{【知】}
+    \renewcommand\wisstatname{【判】}
+    \renewcommand\chastatname{【魅】}
+    % Monster details
+    \renewcommand\skillsname{技能：}
+    \renewcommand\dimmname{ダメージ完全耐性：}
+    \renewcommand\dvulname{ダメージ脆弱性：}
+    \renewcommand\dresname{ダメージ抵抗：}
+    \renewcommand\cimmname{状態完全耐性：}
+    \renewcommand\savesname{セーブ：}
+    \renewcommand\sensesname{感覚：}
+    \renewcommand\languagesname{言語：}
+    \renewcommand\challengename{脅威度：}
+    \renewcommand\xpname{XP}
+    % Monster attack
+    \renewcommand\ftname{フィート}
+    \renewcommand\meleeattackname{近接武器攻撃：}
+    \renewcommand\rangedattackname{遠隔武器攻撃：}
+    \renewcommand\meleeorrangedattackname{近接／遠隔武器攻撃：}
+    \renewcommand\orname{または}
+    \renewcommand\tohitname{攻撃} % TODO: This should go *before* the modifier, i.e. "+4 to hit" becomes "攻撃＋４"
+    \renewcommand\defaulttargetsname{目標１つ}
+    \renewcommand\reachname{間合い}
+    \renewcommand\rangename{射程}
+    \renewcommand\hitname{ヒット：}
+    \renewcommand\damagename{ダメージ}
+    \renewcommand\plusname{および}
+    % Spell levels
+    \renewcommand\spellcantripsname{初級呪文}
+    \renewcommand\spellfirstlevelname{１レベル}
+    \renewcommand\spellsecondlevelname{２レベル}
+    \renewcommand\spellthirdlevelname{３レベル}
+    \renewcommand\spellfourthlevelname{４レベル}
+    \renewcommand\spellfifthlevelname{５レベル}
+    \renewcommand\spellsixthlevelname{６レベル}
+    \renewcommand\spellseventhlevelname{７レベル}
+    \renewcommand\spelleighthlevelname{８レベル}
+    \renewcommand\spellninthlevelname{９レベル}
+    % Spell slots
+    \renewcommand\spellatwillname{無限回}
+    \renewcommand\spelloneslotname{１スロット}
+    \renewcommand\spelltwoslotsname{２スロット}
+    \renewcommand\spellthreeslotsname{３スロット}
+    \renewcommand\spellfourslotsname{４スロット}
+    % Innate spellcasting
+    \renewcommand\innateatwillname{無限回}
+    \renewcommand\numberperdayname{|1|回／日}
+    \renewcommand\numberperdayeachname{|1|回／日ずつ} % TODO: Confirm official translation
+    % Spell header
+    \renewcommand\spellcastingtimename{発動時間}
+    \renewcommand\spellrangename{射程}
+    \renewcommand\spellcomponentsname{構成要素}
+    \renewcommand\spelldurationname{持続時間}
+    % Miscellaneous
+    \renewcommand\dname{d}
+  }
+
 % Russian captions
 \addto\captionsrussian
   {


### PR DESCRIPTION
Here is a Japanese translation for the captions file.  I have used the official wording from the Japanese sourcebooks wherever I could find it.  The only instance I couldn't find is `numberperdayeachname`, so I've supplied my own translation for now and left a comment to that effect.

Other than that, there are two remaining issues, which I have detailed here:

- Monster attack helper assumes English grammar https://github.com/rpgtex/DND-5e-LaTeX-Template/issues/190#issuecomment-510753340
- Add punctuation to captions #212