### PR TITLE
0.8.x backwards compatibility fixes

### DIFF
--- a/dndcore.def
+++ b/dndcore.def
@@ -73,20 +73,21 @@
 % Load other modules of this package after all dependencies to avoid load order
 % conflicts (e.g., package options).
 % Low-level modules first.
-\RequirePackage {lib/compat}      % compatibility definitions
-\RequirePackage {lib/dndutility}  % utility functions
-\RequirePackage {lib/dndcolors}   % color definitions
-\RequirePackage {lib/dndfonts}    % font definitions
-\RequirePackage {lib/dndstrings}  % Load document strings
+\RequirePackage {lib/compat}        % compatibility definitions
+\RequirePackage {lib/dndutility}    % utility functions
+\RequirePackage {lib/dndcolors}     % color definitions
+\RequirePackage {lib/dndfonts}      % font definitions
+\RequirePackage {lib/dndstrings}    % Load document strings
+\RequirePackage {lib/dnddeprecated} % Deprecated macros
 
 % Main modules in alphabetical order
-\RequirePackage {lib/dndcomment}   % inline comment boxes
-\RequirePackage {lib/dndheader}    % fancy headers and footers
-\RequirePackage {lib/dndmonster}   % \monsterbox definition
-\RequirePackage {lib/dndpaperbox}  % \paperbox definition
-\RequirePackage {lib/dndquote}     % \quotebox definition
-\RequirePackage {lib/dndreadaloud} % read-aloud text
-\RequirePackage {lib/dndsections}  % section styling
-\RequirePackage {lib/dndsidebar}   % sidebars
-\RequirePackage {lib/dndspell}     % \spell definition
-\RequirePackage {lib/dndtable}     % \dndtable definition
+\RequirePackage {lib/dndcomment}    % inline comment boxes
+\RequirePackage {lib/dndheader}     % fancy headers and footers
+\RequirePackage {lib/dndmonster}    % \monsterbox definition
+\RequirePackage {lib/dndpaperbox}   % \paperbox definition
+\RequirePackage {lib/dndquote}      % \quotebox definition
+\RequirePackage {lib/dndreadaloud}  % read-aloud text
+\RequirePackage {lib/dndsections}   % section styling
+\RequirePackage {lib/dndsidebar}    % sidebars
+\RequirePackage {lib/dndspell}      % \spell definition
+\RequirePackage {lib/dndtable}      % \dndtable definition

--- a/lib/dndcolors.sty
+++ b/lib/dndcolors.sty
@@ -52,10 +52,10 @@
 % New interface
 \NewDocumentCommand {\DndSetThemeColor} { O {themecolor} }
   {
-    \colorlet {themecolor}      {#1}
+    \colorlet {themecolor}   {#1}
     \colorlet {commentcolor} {#1}
-    \colorlet {sidebarcolor}   {#1}
-    \colorlet {tablecolor}      {#1}
+    \colorlet {sidebarcolor} {#1}
+    \colorlet {tablecolor}   {#1}
   }
 
 % Backwards-compatible aliases and colours
@@ -63,3 +63,8 @@
 \colorlet {itemtablepink} {DmgCoral}
 \colorlet {monstertan}    {statblockbg}
 \definecolor {monstertandark} {HTML} {F0DBB5}
+
+% Old interface
+\colorlet {commentboxcolor} {commentcolor}
+\colorlet {paperboxcolor}   {sidebarcolor}
+\colorlet {quoteboxcolor}   {readaloudcolor}

--- a/lib/dnddeprecated.sty
+++ b/lib/dnddeprecated.sty
@@ -1,0 +1,15 @@
+% Either hilariously, or infuriatingly, the \ifcommandkey
+% implementation is buggy. Here is a re-implementation
+% from tex.stackexchange.
+\begingroup
+  \makeatletter
+  \catcode`\/=8 %
+  \@firstofone
+    {
+      \endgroup
+      \renewcommand{\ifcommandkey}[1]{%
+        \csname @\expandafter \expandafter \expandafter
+        \expandafter \expandafter \expandafter  \expandafter
+        \kcmd@nbk \commandkey {#1}//{first}{second}//oftwo\endcsname
+      }
+  }

--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -131,8 +131,6 @@
   \endgroup%
 }
 
-\ExplSyntaxOff
-
 \NewDocumentEnvironment{monsteraction}{o}{%
   \IfValueTF{#1}{%
     \par\medskip\noindent\emph{\textbf{#1.}}%
@@ -147,7 +145,7 @@
 \setlist[dnd@monsterattrs]{
   before=\color{titlered},
   font=\DndFontStatBlockBody,
-  labelsep=\wordsep,
+  labelsep=\l__dnd_space_dim,
   noitemsep,
   nosep,
 }
@@ -334,6 +332,9 @@
   \end{monsteraction}
 }
 
+% New interface
+\ExplSyntaxOn
+
 \NewDocumentCommand {\DndCRExp} { m }
   {
     \str_case_e:nnF {#1}
@@ -376,9 +377,6 @@
       }
       {#1}
   }
-
-% New interface
-\ExplSyntaxOn
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Monster environments

--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -320,9 +320,9 @@
   ]{%
   \begin{monsteraction}[\commandkey{name}]
     \IfStrEqCase{\commandkey{type}}{%
-      {melee}{\textit{\meleeattackname:} \dnd@hit{mod}, \reachname\ \commandkey{reach} \unitsname}%
-      {ranged}{\textit{\rangedattackname:} \dnd@hit{mod}, \rangename\ \commandkey{range} \unitsname}%
-      {both}{\textit{\meleeorrangedattackname:} \dnd@hit{mod}, \reachname\ \commandkey{reach} \unitsname\ \orname\ \rangename\ \commandkey{range} \unitsname}%
+      {melee}{\textit{\DndCaption{\meleeattackname}{\weaponname}:} \dnd@hit{mod}, \reachname\ \commandkey{reach} \unitsname}%
+      {ranged}{\textit{\DndCaption{\rangedattackname}{\weaponname}:} \dnd@hit{mod}, \rangename\ \commandkey{range} \unitsname}%
+      {both}{\textit{\DndCaption{\meleeorrangedattackname}{\weaponname}:} \dnd@hit{mod}, \reachname\ \commandkey{reach} \unitsname\ \orname\ \rangename\ \commandkey{range} \unitsname}%
     }[]%
     , \commandkey{targets}.
     \textit{\hitname:} \dnd@damage{dmg}{dmgtype}%
@@ -712,7 +712,7 @@
 
 % Inline header for monster actions - similar to a paragraph
 \NewDocumentCommand {\DndMonsterAction} {m}
-  { \unskip \vspace{ 2.5pt plus 1pt minus 1pt } \noindent \textsl { \textbf {#1.} } }
+  { \par \smallskip \noindent \textsl { \textbf {#1.} } }
 
 % Inline header for monster sub actions - similar to a subparagraph
 \NewDocumentCommand {\DndMonsterSubAction} {m}

--- a/lib/dndstrings.sty
+++ b/lib/dndstrings.sty
@@ -14,6 +14,10 @@
     \group_end:
   }
 
+% Document-level version for backwards compatibility
+\NewDocumentCommand{\DndCaption}{ m m }
+  { \__dnd_caption:nn {#1} {#2} }
+
 % Define all strings as new macros instead of hardcoding them in the
 % TeX files. This then allows us to add captions for multilanguage support.
 


### PR DESCRIPTION
Fixes several build errors when building documents in 0.8.x that previously used 0.7.x. by adding missing colors and adjusting expl syntax.

I don't think I can do anything about the "lonely item" error when using `\DndInnateSpellLevel` and `\DndMonsterSpellLevel`. Those were only around for a short time in 0.7.x and were changed to be part of a list in 0.8.x for better control of format and spacing. The fix there is to wrap the items in a `DndMonsterSpells` environment.

closes #222
closes #223