### PR TITLE
Change tohitname to be parameterised

### DIFF
--- a/lib/dndmonster.sty
+++ b/lib/dndmonster.sty
@@ -231,8 +231,9 @@
 }
 
 \newcommand{\dnd@hit}[1]{%
-  \commandkey{#1}\ \tohitname%
+  \__dnd_caption:nn {\tohitname} {#1}
 }
+
 \newcommand{\dnd@damage}[2]{%
   \commandkey{#1}\ \commandkey{#2}\ \damagename%
 }
@@ -845,11 +846,6 @@
     extra .value_required:n = true,
   }
 
-\cs_new_protected:Npn \__dnd_monster_to_hit:
-  {
-    \l__mod_tl\ \tohitname
-  }
-
 \cs_new_protected:Npn \__dnd_monster_reach:
   {
     \reachname\ \l__reach_tl\ \unitsname
@@ -888,15 +884,15 @@
         {
           { melee }
             {
-              \textit{ \__dnd_caption:nn {\meleeattackname} {\l__dnd_attack_type_tl} : } ~ \__dnd_monster_to_hit:, ~ \__dnd_monster_reach:
+              \textit{ \__dnd_caption:nn {\meleeattackname} {\l__dnd_attack_type_tl} : } \__dnd_caption:nn {\tohitname} {\l__mod_tl}, ~ \__dnd_monster_reach:
             }
           { ranged }
             {
-              \textit{ \__dnd_caption:nn {\rangedattackname} {\l__dnd_attack_type_tl} : } ~ \__dnd_monster_to_hit:, ~ \__dnd_monster_range:
+              \textit{ \__dnd_caption:nn {\rangedattackname} {\l__dnd_attack_type_tl} : } \__dnd_caption:nn {\tohitname} {\l__mod_tl}, ~ \__dnd_monster_range:
             }
         }
         {% Melee and Ranged is the default
-          \textit{ \__dnd_caption:nn {\meleeorrangedattackname} {\l__dnd_attack_type_tl} : } ~ \__dnd_monster_to_hit:, ~ \__dnd_monster_reach:\ \orname\ \__dnd_monster_range:
+          \textit{ \__dnd_caption:nn {\meleeorrangedattackname} {\l__dnd_attack_type_tl} : } \__dnd_caption:nn {\tohitname} {\l__mod_tl}, ~ \__dnd_monster_reach:\ \orname\ \__dnd_monster_range:
         }
       , ~ \l__targets_tl. ~
       \textit { \hitname : } ~

--- a/lib/dndstrings.sty
+++ b/lib/dndstrings.sty
@@ -55,7 +55,7 @@
 \newcommand\rangedattackname{Ranged~|1|~Attack}
 \newcommand\meleeorrangedattackname{Melee~or~Ranged~|1|~Attack}
 \newcommand\orname{or}
-\newcommand\tohitname{to~hit}
+\newcommand\tohitname{|1|~to~hit}
 \newcommand\defaulttargetsname{one~target}
 \newcommand\reachname{reach}
 \newcommand\rangename{range}

--- a/lib/languages/_template.sty
+++ b/lib/languages/_template.sty
@@ -33,7 +33,7 @@
     \renewcommand\rangedattackname{Ranged~|1|~Attack}
     \renewcommand\meleeorrangedattackname{Melee~or~Ranged~|1|~Attack}
     \renewcommand\orname{or}
-    \renewcommand\tohitname{to~hit}
+    \renewcommand\tohitname{|1|~to~hit}
     \renewcommand\defaulttargetsname{one~target}
     \renewcommand\reachname{reach}
     \renewcommand\rangename{range}

--- a/lib/languages/italian.sty
+++ b/lib/languages/italian.sty
@@ -35,7 +35,7 @@
     \renewcommand\rangedattackname{Attacco~con~|1|~a~Distanza}
     \renewcommand\meleeorrangedattackname{Attacco~con~|1|~da~Mischia~o~a~Distanza}
     \renewcommand\orname{o}
-    \renewcommand\tohitname{per~colpire}
+    \renewcommand\tohitname{|1|~per~colpire}
 %    \renewcommand\defaulttargetsname{one~target}
     \renewcommand\reachname{portata}
     \renewcommand\rangename{gittata}

--- a/lib/languages/japanese.sty
+++ b/lib/languages/japanese.sty
@@ -31,7 +31,7 @@
     \renewcommand\rangedattackname{遠隔武器攻撃：}
     \renewcommand\meleeorrangedattackname{近接／遠隔武器攻撃：}
     \renewcommand\orname{または}
-    \renewcommand\tohitname{攻撃} % TODO: This should go *before* the modifier, i.e. "+4 to hit" becomes "攻撃＋４"
+    \renewcommand\tohitname{攻撃|1|}
     \renewcommand\defaulttargetsname{目標１つ}
     \renewcommand\reachname{間合い}
     \renewcommand\rangename{射程}

--- a/lib/languages/ngerman.sty
+++ b/lib/languages/ngerman.sty
@@ -28,7 +28,7 @@
     \renewcommand\rangedattackname{Fernkampf-Waffenangriff}
     \renewcommand\meleeorrangedattackname{Nah-~oder~Fernkampf-Waffenangriff}
     \renewcommand\orname{oder}
-    \renewcommand\tohitname{zum~Treffen}
+    \renewcommand\tohitname{|1|~zum~Treffen}
     \renewcommand\defaulttargetsname{ein~Ziel}
     \renewcommand\reachname{Reichweite}
     \renewcommand\rangename{Reichweite}

--- a/lib/languages/russian.sty
+++ b/lib/languages/russian.sty
@@ -34,7 +34,7 @@
 %    \renewcommand\rangedattackname{Ranged~|1|~Attack}
 %    \renewcommand\meleeorrangedattackname{Melee~or~Ranged~|1|~Attack}
 %    \renewcommand\orname{or}
-%    \renewcommand\tohitname{to~hit}
+%    \renewcommand\tohitname{|1|~to~hit}
 %    \renewcommand\defaulttargetsname{one~target}
 %    \renewcommand\reachname{reach}
 %    \renewcommand\rangename{range}


### PR DESCRIPTION
This allows us to choose the location of the text relative to the modifier.

Japanese has been updated to make use of this to output 「攻撃＋１」 instead of 「＋１攻撃」.  All other languages should remain unchanged.