### PR TITLE
Keep table header and body together.

### DIFF
--- a/lib/dndtable.sty
+++ b/lib/dndtable.sty
@@ -53,7 +53,7 @@
     \tl_if_empty:NF \l__dnd_table_header_tl
       {
         \group_begin:
-          \DndFontTableTitle \l__dnd_table_header_tl
+          \DndFontTableTitle \l__dnd_table_header_tl \nopagebreak
           \par \vspace{ 5pt plus 2pt minus 2pt } \noindent
         \group_end:
       }


### PR DESCRIPTION
Inserting a `\nopagebreak` between the header and the space before the table helps keep the header and table together.

Closes #231 