### PR TITLE
Fix TeX engine checks

### DIFF
--- a/dndcore.def
+++ b/dndcore.def
@@ -13,7 +13,6 @@
 \RequirePackage {etoolbox}
 \RequirePackage {textcomp,gensymb} % degree symbol for italian ordinals
 \RequirePackage {hang} % hanging paragraphs
-%\RequirePackage {ifluatex}
 \RequirePackage {keycommand}
 \RequirePackage [autolanguage] {numprint} % localization of thousands separator
 \RequirePackage {tabularx} % variable-width table columns

--- a/dndcore.def
+++ b/dndcore.def
@@ -13,7 +13,7 @@
 \RequirePackage {etoolbox}
 \RequirePackage {textcomp,gensymb} % degree symbol for italian ordinals
 \RequirePackage {hang} % hanging paragraphs
-\RequirePackage {ifluatex}
+%\RequirePackage {ifluatex}
 \RequirePackage {keycommand}
 \RequirePackage [autolanguage] {numprint} % localization of thousands separator
 \RequirePackage {tabularx} % variable-width table columns

--- a/lib/dndtable.sty
+++ b/lib/dndtable.sty
@@ -53,7 +53,7 @@
     \tl_if_empty:NF \l__dnd_table_header_tl
       {
         \group_begin:
-          \DndFontTableTitle \l__dnd_table_header_tl \nopagebreak
+          \DndFontTableTitle \l__dnd_table_header_tl
           \par \vspace{ 5pt plus 2pt minus 2pt } \noindent
         \group_end:
       }

--- a/lib/dndtable.sty
+++ b/lib/dndtable.sty
@@ -53,7 +53,7 @@
     \tl_if_empty:NF \l__dnd_table_header_tl
       {
         \group_begin:
-          \DndFontTableTitle \l__dnd_table_header_tl
+          \DndFontTableTitle \l__dnd_table_header_tl \nopagebreak
           \par \vspace{ 5pt plus 2pt minus 2pt } \noindent
         \group_end:
       }

--- a/packages.txt
+++ b/packages.txt
@@ -29,7 +29,7 @@ courier
 ec
 enumitem
 environ
-epstopdf-base
+epstopdf-pkg
 etex-pkg
 etoolbox
 fancyhdr

--- a/packages.txt
+++ b/packages.txt
@@ -19,6 +19,7 @@
 #
 
 amsfonts
+atbegshi
 babel
 babel-english
 bookman

--- a/packages.txt
+++ b/packages.txt
@@ -48,6 +48,7 @@ l3packages
 latex-fonts
 lettrine
 lm
+ltxcmds
 luacolor
 microtype
 minifp

--- a/packages.txt
+++ b/packages.txt
@@ -29,6 +29,7 @@ courier
 ec
 enumitem
 environ
+epstopdf
 etex-pkg
 etoolbox
 fancyhdr
@@ -47,6 +48,7 @@ l3packages
 latex-fonts
 lettrine
 lm
+luacolor
 microtype
 minifp
 ms

--- a/packages.txt
+++ b/packages.txt
@@ -37,8 +37,6 @@ fp
 geometry
 gillius
 hang
-ifluatex
-ifxetex
 initials
 keycommand
 kpfonts

--- a/packages.txt
+++ b/packages.txt
@@ -54,6 +54,7 @@ numprint
 oberdiek
 pgf
 psnfss
+ragged2e
 tcolorbox
 titlesec
 tocloft

--- a/packages.txt
+++ b/packages.txt
@@ -40,6 +40,7 @@ hang
 initials
 keycommand
 kpfonts
+kvsetkeys
 l3backend
 l3kernel
 l3packages

--- a/packages.txt
+++ b/packages.txt
@@ -29,7 +29,7 @@ courier
 ec
 enumitem
 environ
-epstopdf
+epstopdf-base
 etex-pkg
 etoolbox
 fancyhdr


### PR DESCRIPTION
ifluatex and ifxetex packages seem to have been pulled from the repository, causing build errors in the continuous integration. Package iftex seems to be loaded by default and has macros for the major engines.