### PR TITLE
Add luahbtex engine

### DIFF
--- a/bin/install-texlive
+++ b/bin/install-texlive
@@ -33,4 +33,5 @@ tlmgr install \
   latex \
   latex-bin \
   latexmk \
+  luahbtex \
   xetex


### PR DESCRIPTION
MikTeX updated fairly recently to use the `luahbtex` engine, maybe CircleCI just updated.  It fixes the issue I was having with the tests not working, and it looks like @kauron had it too.