### PR TITLE
Fix the label for the color table

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -266,7 +266,7 @@ The |DndMonster| environment is used to typeset monster and NPC stat blocks. The
 \chapter{Colors}
 
 \begin{table*}[b]
-  \caption{\DndFontTableTitle{}Colors Supported by this Package\label{tab:colors}}
+  \caption{\DndFontTableTitle{}Colors Supported by this Package}\label{tab:colors}
 
   \begin{tabularx}{\linewidth}{lX}
     \textbf{Color}                  & \textbf{Description} \\


### PR DESCRIPTION
The label was inside of the `\caption`