### PR TITLE
Fix contour to break on spaces and handle new lines

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -48,7 +48,7 @@
 
 \part{Layout}
 
-\chapter[Personality and \newline Background]{Personality and ~ Background}
+\chapter{Sections}
 
 \DndDropCapLine{T}{his package is designed to aid you in} writing beautifully typeset documents for the fifth edition of the world's greatest roleplaying game. It starts by adjusting the section formatting from the defaults in \LaTeX{} to something a bit more familiar to the reader. The chapter formatting is displayed above.
 

--- a/example.tex
+++ b/example.tex
@@ -48,7 +48,7 @@
 
 \part{Layout}
 
-\chapter{Sections}
+\chapter[Personality and \newline Background]{Personality and ~ Background}
 
 \DndDropCapLine{T}{his package is designed to aid you in} writing beautifully typeset documents for the fifth edition of the world's greatest roleplaying game. It starts by adjusting the section formatting from the defaults in \LaTeX{} to something a bit more familiar to the reader. The chapter formatting is displayed above.
 

--- a/lib/dndfonts.sty
+++ b/lib/dndfonts.sty
@@ -5,6 +5,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \RequirePackage{lettrine}
 \RequirePackage{Royal}
+\RequirePackage[auto]{contour}
 
 \bool_if:NT \l__dnd_layout_bool
   {
@@ -23,16 +24,21 @@
   }
 
 % Add the outlines
-  \NewDocumentCommand{\DndContour}{ O{} m }
+\cs_new_protected:Npn \__dnd_contour_preserve_newline:nn #1#2
   {
-  \textpdfrender
-    {
-    TextRenderingMode = FillStroke,
-    StrokeColor =       contourgray,
-    LineWidth =         0.03ex,
-    RenderingIntent =   RelativeColorimetric,
-    #1
-    }{#2}
+    \group_begin:
+    \seq_set_split:Nnn \l_tmpa_seq { \newline } { #2 }
+    \seq_set_map:NNn \l_tmpb_seq \l_tmpa_seq { \exp_not:n {\contour{#1}{##1}} }
+    \seq_use:Nn \l_tmpb_seq { \newline }
+    \group_end:
+  }
+
+\NewDocumentCommand{\DndContour}{ O{contourgray} m }
+  {
+    \group_begin:
+    \seq_set_split:Nnn \l_tmpa_seq { ~ } { #2 }
+    \seq_map_inline:Nn \l_tmpa_seq { \__dnd_contour_preserve_newline:nn{#1}{##1} ~ } \unskip
+    \group_end:
   }
 
 \keys_define:nn { dnd / fonts }

--- a/lib/dndfonts.sty
+++ b/lib/dndfonts.sty
@@ -23,24 +23,6 @@
       { \sffamily }
   }
 
-% Add the outlines
-\cs_new_protected:Npn \__dnd_contour_preserve_newline:nn #1#2
-  {
-    \group_begin:
-    \seq_set_split:Nnn \l_tmpa_seq { \newline } { #2 }
-    \seq_set_map:NNn \l_tmpb_seq \l_tmpa_seq { \exp_not:n {\contour{#1}{##1}} }
-    \seq_use:Nn \l_tmpb_seq { \newline }
-    \group_end:
-  }
-
-\NewDocumentCommand{\DndContour}{ O{contourgray} m }
-  {
-    \group_begin:
-    \seq_set_split:Nnn \l_tmpa_seq { ~ } { #2 }
-    \seq_map_inline:Nn \l_tmpa_seq { \__dnd_contour_preserve_newline:nn{#1}{##1} ~ } \unskip
-    \group_end:
-  }
-
 \keys_define:nn { dnd / fonts }
   {
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -332,4 +314,28 @@
       ]
       {#2}
       {#3}
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Contour that can break across lines. Can accept \newline to force a break.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\regex_const:Nn \c__not_newlines_regex { (.+) }
+\seq_new:N \l__contour_sections_seq
+
+\cs_new_protected:Npn \__dnd_contour_preserve_space:nn #1#2
+  {
+    \group_begin:
+    \seq_set_split:Nnn \l_tmpa_seq { ~ } { #2 }
+    \seq_set_map:NNn \l_tmpb_seq \l_tmpa_seq { \exp_not:n {\contour{#1}{##1}} }
+    \seq_use:Nn \l_tmpb_seq { ~ }
+    \group_end:
+  }
+
+\NewDocumentCommand{\DndContour}{ O{contourgray} m }
+  {
+    \group_begin:
+    \seq_set_split:Nnn \l_tmpa_seq { \newline } { #2 }
+    \seq_set_map:NNn \l_tmpb_seq \l_tmpa_seq { \exp_not:n {\__dnd_contour_preserve_space:nn{#1}{##1}} }
+    \seq_use:Nn \l_tmpb_seq { \newline }
+    \group_end:
   }

--- a/lib/dndsections.sty
+++ b/lib/dndsections.sty
@@ -2,8 +2,6 @@
 
 \bool_if:NT \l__dnd_layout_bool
 {
-  \RequirePackage{pdfrender}
-
   % Change part numbering to Arabic numbers from Roman numerals
   \renewcommand{\thepart}{\arabic{part}}
 
@@ -23,7 +21,7 @@
     [display]
     { \centering \DndFontPart } % format
     { \DndContour{\partname\ \thepart} } % label
-    {2ex} % sep
+    { 2ex } % sep
     { \DndContour } % before-code
 
   % Chapter
@@ -31,7 +29,7 @@
     { \DndFontChapter } % format
     { \DndContour{\chaptertitlename\ \thechapter :} } % label
     { \wordsep } % sep
-    {\DndContour} % before-code
+    { \DndContour } % before-code
 
   \titlespacing* {\chapter}
     { 0pt }  % left
@@ -47,7 +45,7 @@
 
   \titlespacing* { \section }
     { 0pt } % left
-  { 1.3ex plus .43ex minus .43ex } % before-sep
+    { 1.3ex plus .43ex minus .43ex } % before-sep
     { 0pt } % after-sep
 
   % Subsection
@@ -60,7 +58,7 @@
 
   \titlespacing*{ \subsection }
     { 0pt } % left
-  { 1.4ex plus .47ex minus .47ex } % before-sep
+    { 1.4ex plus .47ex minus .47ex } % before-sep
     { 1.2ex } % after-sep
 
   % Subsubsection

--- a/packages.txt
+++ b/packages.txt
@@ -26,6 +26,7 @@ bookman
 cfr-initials
 cm
 colortbl
+contour
 courier
 ec
 enumitem


### PR DESCRIPTION
Moving back to contour as it gives a more pleasing visual result than pdfrender for thick outlines. Added ability for contour to break across lines by splitting the string on spaces and newlines before applying contour. I will optimize it a bit, but I wanted to get opinions on the general strategy first.