### PR TITLE
Add \tocchapterabbreviationname to _template.sty

### DIFF
--- a/lib/languages/_template.sty
+++ b/lib/languages/_template.sty
@@ -69,4 +69,5 @@
 %    % Miscellaneous
     \renewcommand\pageabbreviationname{pg.}
     \renewcommand\dname{d}
+    \renewcommand\tocchapterabbreviationname{Ch.}
   }

--- a/lib/languages/italian.sty
+++ b/lib/languages/italian.sty
@@ -71,5 +71,5 @@
     % Miscellaneous
 %    \renewcommand\pageabbreviationname{pg.}
 %    \renewcommand\dname{d}
-%    \newcommand\tocchapterabbreviationname{Ch.}
+%    \renewcommand\tocchapterabbreviationname{Ch.}
   }

--- a/lib/languages/japanese.sty
+++ b/lib/languages/japanese.sty
@@ -66,5 +66,5 @@
     \renewcommand\spelldurationname{持続時間}
     % Miscellaneous
     \renewcommand\dname{d}
-%    \newcommand\tocchapterabbreviationname{Ch.}
+%   \renewcommand\tocchapterabbreviationname{Ch.}
   }

--- a/lib/languages/ngerman.sty
+++ b/lib/languages/ngerman.sty
@@ -62,7 +62,7 @@
     \renewcommand\spellcomponentsname{Komponenten}
     \renewcommand\spelldurationname{Wirkungsdauer}
     % Miscellaneous
-%    \renewcommand\pageabbreviationname{pg.}
+%   \renewcommand\pageabbreviationname{pg.}
     \renewcommand\dname{W}
-%    \newcommand\tocchapterabbreviationname{Ch.}
+%   \renewcommand\tocchapterabbreviationname{Ch.}
   }

--- a/lib/languages/russian.sty
+++ b/lib/languages/russian.sty
@@ -70,5 +70,5 @@
 %    % Miscellaneous
 %    \renewcommand\pageabbreviationname{pg.}
 %    \renewcommand\dname{d}
-%     \newcommand\tocchapterabbreviationname{Ch.}
+%    \renewcommand\tocchapterabbreviationname{Ch.}
   }

--- a/lib/languages/spanish.sty
+++ b/lib/languages/spanish.sty
@@ -65,6 +65,7 @@
     \renewcommand\spelldurationname{Duración}
     % Miscellaneous
     \renewcommand\dname{d}
-%    \renewcommand\pageabbreviationname{pg.}
+%   \renewcommand\pageabbreviationname{pg.}
+%   \renewcommand\tocchapterabbreviationname{Ch.}
   }
 


### PR DESCRIPTION
_template.sty is missing the `\tocchapterabbreviationname` command.