### PR TITLE
Add package option to use metric system units

### DIFF
--- a/dndoptions.clo
+++ b/dndoptions.clo
@@ -31,9 +31,11 @@
 \bool_new:N \l__dnd_multitoc_bool
 \bool_new:N \l__dnd_layout_bool
 \bool_new:N \l__dnd_no_deprecated_code_bool
+\bool_new:N \l__dnd_metric_system_bool
 
 \bool_set_true:N \l__dnd_multitoc_bool
 \bool_set_eq:NN \l__dnd_layout_bool \c__dnd_isclass_bool
+\bool_set_false:N \l__dnd_metric_system_bool
 
 % BEGIN section to remove in version 1.0.0
 \bool_set_true:N \l__dnd_layout_bool
@@ -93,6 +95,16 @@
       }, % Remove and replace with .bool_set:N in 1.0.0
     layout .value_required:n = true,
 
+    units .choice:,
+    units / metric .code:n =
+      {
+        \bool_set_true:N \l__dnd_metric_system_bool
+      },
+    units / imperial .code:n =
+      {
+        \bool_set_false:N \l__dnd_metric_system_bool
+      },
+  
     % Unknown option handling
     unknown .code:n =
     {

--- a/example.tex
+++ b/example.tex
@@ -157,7 +157,7 @@ The |DndTable| colors the even rows and is set to the width of a line by default
     \DndMonsterBasics[
         armor-class = {9 (12 with \emph{mage armor})},
         hit-points  = {\DndDice{3d8 + 3}},
-        speed       = {30 ft., fly 30 ft.},
+        speed       = {30 \unitsname, fly 30 \unitsname},
       ]
 
     \DndMonsterAbilityScores[
@@ -176,7 +176,7 @@ The |DndTable| colors the even rows and is set to the width of a line by default
         %damage-resistances = {bludgeoning, piercing, and slashing from nonmagical attacks},
         %damage-immunities = {poison},
         %condition-immunities = {poisoned},
-        senses = {darkvision 60 ft., passive Perception 10},
+        senses = {darkvision 60 \unitsname, passive Perception 10},
         languages = {Common, Goblin, Undercommon},
         challenge = 1,
       ]

--- a/lib/dndstrings.sty
+++ b/lib/dndstrings.sty
@@ -52,7 +52,13 @@
 \newcommand\xpname{XP}
 
 % Attacks
-\newcommand\unitsname{ft.}
+\bool_if:NTF \l__dnd_metric_system_bool
+{
+  \renewcommand\unitsname{m.}
+}
+{
+  \renewcommand\unitsname{ft.}
+}
 \newcommand\weaponname{Weapon}
 \newcommand\spellname{Spell}
 \newcommand\meleeattackname{Melee~|1|~Attack}

--- a/lib/dndstrings.sty
+++ b/lib/dndstrings.sty
@@ -50,15 +50,13 @@
 \newcommand\languagesname{Languages}
 \newcommand\challengename{Challenge}
 \newcommand\xpname{XP}
-
+\newcommand\unitsname{ft.}
 % Attacks
-\bool_if:NTF \l__dnd_metric_system_bool
+\bool_if:NT \l__dnd_metric_system_bool
 {
   \renewcommand\unitsname{m.}
 }
-{
-  \renewcommand\unitsname{ft.}
-}
+
 \newcommand\weaponname{Weapon}
 \newcommand\spellname{Spell}
 \newcommand\meleeattackname{Melee~|1|~Attack}

--- a/lib/languages/_template.sty
+++ b/lib/languages/_template.sty
@@ -26,7 +26,13 @@
     \renewcommand\challengename{Challenge}
     \renewcommand\xpname{XP}
     % Monster attack
-    \renewcommand\unitsname{ft.}
+    \bool_if:NTF \l__dnd_metric_system_bool
+    {
+      \renewcommand\unitsname{m.}
+    }
+    {
+      \renewcommand\unitsname{ft.}
+    }
     \renewcommand\weaponname{Weapon}
     \renewcommand\spellname{Spell}
     \renewcommand\meleeattackname{Melee~|1|~Attack}

--- a/lib/languages/spanish.sty
+++ b/lib/languages/spanish.sty
@@ -25,7 +25,13 @@
     \renewcommand\challengename{Desafío}
     \renewcommand\xpname{PE}
     % Monster attack
-    \renewcommand\unitsname{pies}
+    \bool_if:NTF \l__dnd_metric_system_bool
+      {
+        \renewcommand\unitsname{m}
+      }
+      {
+        \renewcommand\unitsname{ft}
+      }
     \renewcommand\meleeattackname{Ataque~de~arma~cuerpo~a~cuerpo}
     \renewcommand\rangedattackname{Ataque~de~arma~a~distancia}
     \renewcommand\meleeorrangedattackname{Ataque~de~arma~cuerpo~a~cuerpo~o~a~distancia}
@@ -67,4 +73,3 @@
     \renewcommand\dname{d}
 %    \renewcommand\pageabbreviationname{pg.}
   }
-


### PR DESCRIPTION
I added a new package option called `units` that can accept two values: `metric` and `imperial`. `imperial` does nothing new and `metric` changes the units from feet to meters.

I also changed the spanish unit names from `pies` to `ft`, which is one of the correct abbreviations in our language. We don't use a point at the end. It still isn't the official translation but is close enough (in the 3.5e manuals `30 ft.` get translated to `30'`, but the template inserts a space and turns it into `30 '` so I couldn't do that. Maybe I'll open an issue/PR about it later)

Some kind soul should take a look at the rest of the languages. For example, italian uses (incorrectly) `m.` by default.